### PR TITLE
fix: 修复valine访问计数模式在mobile状态下无法展示具体数值的问题

### DIFF
--- a/layout/_partial/post/article.ejs
+++ b/layout/_partial/post/article.ejs
@@ -41,7 +41,7 @@
                 <% if (theme.valine.enable == true && theme.valine.visitor == true) { %>
                 <span id="<%- '/' + page.path %>" class="leancloud_visitors" data-flag-title="<%- page.title %>">
                     <b class="iconfont icon-read"></b> <i><%= __('read_count') %></i>
-                    <i class="leancloud-visitors-count">1000000</i>
+                    <span class="leancloud-visitors-count">1000000</span>
                 </span>
                 <% } %>
                 <% if (theme.busuanzi.enable == true && theme.valine.enable == false) { %>

--- a/layout/_partial/post/item.ejs
+++ b/layout/_partial/post/item.ejs
@@ -38,7 +38,7 @@
                 <% if (theme.valine.enable == true && theme.valine.visitor == true) { %>
                     <span id="<%- '/' + post.path %>" class="leancloud_visitors" data-flag-title="<%- page.title %>">
                         <b class="iconfont icon-read"></b> <i><%= __('read_count') %></i>
-                        <i class="leancloud-visitors-count">1000000</i>
+                        <span class="leancloud-visitors-count">1000000</span>
                     </span>
                 <% } %>
             </p>

--- a/layout/_partial/screen.ejs
+++ b/layout/_partial/screen.ejs
@@ -76,7 +76,7 @@
             <% if (theme.valine.enable == true && theme.valine.visitor == true) { %>
             <span id="<%- '/' + first.path %>" class="leancloud_visitors" data-flag-title="<%- page.title %>">
                 <b class="iconfont icon-read"></b> <i><%= __('read_count') %></i>
-                <i class="leancloud-visitors-count">1000000</i>
+                <span class="leancloud-visitors-count">1000000</span>
             </span>
             <% } %>
         </p>


### PR DESCRIPTION
使用 valine 计数的时候, 在手机上无法展示具体的访问数值, 如图所示.

![批注 2019-12-13 094708](https://user-images.githubusercontent.com/5206136/70763323-a7714000-1d8e-11ea-8e01-e82d3b51f4b0.png)


因为, 标签错误的写成了`<i>`,这种状态在媒体查询是小屏幕的时候会隐藏, 因此改成了和busuanzi计数一样的`<span>`, 可以解决问题
```html
<span id="<%- '/' + first.path %>" class="leancloud_visitors" data-flag-title="<%- page.title %>">
    <b class="iconfont icon-read"></b> <i><%= __('read_count') %></i>
    <i class="leancloud-visitors-count">1000000</i>
</span>
```