### PR TITLE
[bugfix] 修复 hexo 配置项 root 不为网站根目录 '/' 时，主题中部分位置的 favicon 和 cover 图片无法显示的问题

### DIFF
--- a/layout/_partial/post/article.ejs
+++ b/layout/_partial/post/article.ejs
@@ -5,7 +5,7 @@
             animation-duration: 1.2s;
             background-image: 
                 radial-gradient(ellipse closest-side, rgba(0, 0, 0, 0.65), #100e17),
-                url(<%- page.cover || theme.welcome_cover %>);">
+                url(<%- url_for(page.cover || theme.welcome_cover) %>) ">
         </div>
         <div class="else">
             <p class="animated fadeInDown">

--- a/layout/_partial/post/header.ejs
+++ b/layout/_partial/post/header.ejs
@@ -2,7 +2,7 @@
 <div id="top" style="display: block;">
     <div class="bar" style="width: 0;"></div>
     <div class="navigation animated fadeIn fast delay-1s">
-        <img id="home-icon" class="icon-home" src="/img/favicon.png" alt="" data-url="<%= config.url %>">
+        <img id="home-icon" class="icon-home" src="<%- url_for(theme.favicon) %>" alt="" data-url="<%= config.url %>">
         <div id="play-icon" title="Play/Pause" class="iconfont icon-play"></div>
         <h3 class="subtitle"><%- page.title %></h3>
         <div class="social">

--- a/layout/_partial/screen.ejs
+++ b/layout/_partial/screen.ejs
@@ -15,7 +15,7 @@
 <div id="header">
     <div>
         <div class="logo animated fadeInDown">
-            <img src="/img/favicon.png" alt="">
+            <img src="<%- url_for(theme.favicon) %>" alt="">
             <a class="image-logo" href="/"></a>
         </div>
         <ul id="menu-menu" class="menu text-menu">
@@ -38,7 +38,7 @@
             animation-duration: 2.8s;
             background-image:
                 radial-gradient(ellipse closest-side, rgba(0, 0, 0, 0.56), #100e17),
-                url(<%= first.cover || "/img/cover.jpg" %>);">
+                url(<%- url_for(first.cover || "/img/cover.jpg") %>);">
         </div>
     </div>
     <% if ( first ) { %>

--- a/source/css/obsidian.styl
+++ b/source/css/obsidian.styl
@@ -287,11 +287,11 @@ audio {
     background-size: 75px 32px;
     background-repeat: no-repeat;
     background-position: center center;
-    -webkit-mask-box-image: url("/img/logo.png");
+    -webkit-mask-box-image: url("../img/logo.png");
     background-color: white;
     width: 75px;
     height: 32px;
-    mask-image: url("/img/logo.png");
+    mask-image: url("../img/logo.png");
     mask-size: contain;
     transition: background-color 0.5s ease-in-out;
   }
@@ -1802,7 +1802,7 @@ footer {
       background-size: cover;
       background-repeat: no-repeat;
       opacity: 0.85;
-      background-image: radial-gradient(ellipse closest-side, rgba(0, 0, 0, 0.46), #100e17), url(/img/cover.jpg);
+      background-image: radial-gradient(ellipse closest-side, rgba(0, 0, 0, 0.46), #100e17), url("../img/cover.jpg");
       z-index: -1;
       animation-delay: 900ms;
       animation-duration: 1.2s;


### PR DESCRIPTION
原来的代码应该只考虑到博客部署在域名根目录的情况，但有些博客需要部署在二级目录下，例如：http://yourdomain.com/blog/ ，这个时候部分图片例如 favicon.png 和 cover.jpg 因为 url 错误而无法显示。

该 PR 使用 hexo 官方的辅助函数 `url_for()` 修复该问题。

应该可以 Fix #54 