### PR TITLE
[bugfix] 修复主页的标语被背景图片部分遮挡的问题

### DIFF
--- a/source/css/obsidian.styl
+++ b/source/css/obsidian.styl
@@ -168,7 +168,7 @@ audio {
   border-bottom-right-radius: 200px;
 
   .cover {
-    position: absolute;
+    position: relative;
     top: 0;
     left: 30%;
     width: 1200px;


### PR DESCRIPTION
似乎调整一下 position 参数为 relative 就可以 Fixes #57 了